### PR TITLE
Update OptimizelyIntegration to listen to the correct event for Experiment Viewed

### DIFF
--- a/src/main/java/com/segment/analytics/android/integrations/optimizely/OptimizelyIntegration.java
+++ b/src/main/java/com/segment/analytics/android/integrations/optimizely/OptimizelyIntegration.java
@@ -90,16 +90,16 @@ public class OptimizelyIntegration extends Integration<Void> implements Optimize
 
   @Override
   public void onOptimizelyExperimentVisited(OptimizelyExperimentData optimizelyExperimentData) {
-    // Ignore.
+    analytics.track("Experiment Viewed", new Properties() //
+            .putValue("experimentId", optimizelyExperimentData.experimentId)
+            .putValue("experimentName", optimizelyExperimentData.experimentName)
+            .putValue("variationId", optimizelyExperimentData.variationId)
+            .putValue("variationName", optimizelyExperimentData.variationName));
   }
 
   @Override
   public void onOptimizelyExperimentViewed(OptimizelyExperimentData optimizelyExperimentData) {
-    analytics.track("Experiment Viewed", new Properties() //
-        .putValue("experimentId", optimizelyExperimentData.experimentId)
-        .putValue("experimentName", optimizelyExperimentData.experimentName)
-        .putValue("variationId", optimizelyExperimentData.variationId)
-        .putValue("variationName", optimizelyExperimentData.variationName));
+    // Deprecated
   }
 
   @Override public void onOptimizelyEditorEnabled() {

--- a/src/test/java/com/segment/analytics/android/integrations/optimizely/OptimizelyTest.java
+++ b/src/test/java/com/segment/analytics/android/integrations/optimizely/OptimizelyTest.java
@@ -77,7 +77,7 @@ public class OptimizelyTest {
     data.variationId = "qux";
     data.variationName = "qaz";
 
-    integration.onOptimizelyExperimentViewed(data);
+    integration.onOptimizelyExperimentVisited(data);
 
     verify(analytics).track("Experiment Viewed", new Properties() //
         .putValue("experimentId", "bar")


### PR DESCRIPTION
This will resolve the issue referenced in Issue #1.

I chose to keep the event name "Experiment Viewed", for backwards compatibility, but it may also make sense to update it to "Experiment Visited" to reflect the newer naming convention that Optimizely is using.
